### PR TITLE
Feature add option to pick a preferred date for throwback

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -271,9 +271,10 @@ See what you've tweeted on this day in the past.
 
 <script>
     // Set the default date input value to today
-    var date = document.getElementById('date-input');
-    var today = new Date().toISOString().substr(0, 10);
-    date.value = today;
+    var month = document.getElementById('month');
+    var day = document.getElementById('day');
+    month.value = new Date().getMonth() + 1;
+    day.value = new Date().getDate();
 </script>
 
 <script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -59,9 +59,8 @@
         }
 
         .input-group {
-            display: grid;
+            display: inline-grid;
             grid-template-columns: 1fr auto auto auto;
-            width: 50%;
             margin: 32px auto;
         }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,9 +27,6 @@
             padding: 0;
             box-sizing: border-box;
         }
-
-        ::-webkit-datetime-edit-fields-wrapper { background: transparent; }
-        ::-webkit-inner-spin-button { display: none; }
  
         html{ 
             scroll-behavior: smooth;

--- a/docs/index.html
+++ b/docs/index.html
@@ -217,39 +217,7 @@ See what you've tweeted on this day in the past.
             <option value="11">November</option>
             <option value="12">December</option>
         </select>
-        <select name="day" id="day">
-            <option value="1">1</option>
-            <option value="2">2</option>
-            <option value="3">3</option>
-            <option value="4">4</option>
-            <option value="5">5</option>
-            <option value="6">6</option>
-            <option value="7">7</option>
-            <option value="8">8</option>
-            <option value="9">9</option>
-            <option value="10">10</option>
-            <option value="11">11</option>
-            <option value="12">12</option>
-            <option value="13">13</option>
-            <option value="14">14</option>
-            <option value="15">15</option>
-            <option value="16">16</option>
-            <option value="17">17</option>
-            <option value="18">18</option>
-            <option value="19">19</option>
-            <option value="20">20</option>
-            <option value="21">21</option>
-            <option value="22">22</option>
-            <option value="23">23</option>
-            <option value="24">24</option>
-            <option value="25">25</option>
-            <option value="26">26</option>
-            <option value="27">27</option>
-            <option value="28">28</option>
-            <option value="29">29</option>
-            <option value="30">30</option>
-            <option value="31">31</option>
-        </select>
+        <select name="day" id="day"></select>
         <button id="submit-button" type="submit">Show me</button>
     </div>
     <div id="help-text">
@@ -273,8 +241,36 @@ See what you've tweeted on this day in the past.
     // Set the default date input value to today
     var month = document.getElementById('month');
     var date = document.getElementById('day');
+
     month.value = new Date().getMonth() + 1;
+    checkMonth(month.value); // Populate the date options based on the present month
     date.value = new Date().getDate();
+
+    function checkMonth() { // Determine the number of days in the selected month
+        let selectedMonth = Number(month.value);
+        let selectedDate = date.value;
+        if ([1,3,5,7,8,10,12].includes(selectedMonth)) {
+            populateDays(31, selectedDate);
+        } else if ([4,6,9,11].includes(selectedMonth)) {
+            populateDays(30, selectedDate);
+        } else {
+            populateDays(29, selectedDate);
+        }
+    }
+
+
+    function populateDays(numberOfDays, currentDate) {
+        day.innerHTML = null; // Remove the existing days options
+        // Insert options for each day up to "numberOfDays" in the month
+        for (let i = 1; i <= numberOfDays; i++) {
+            day.innerHTML += `<option value="${i}">${i}</option>`;
+        }
+        // This attempts to set the date value to the previously selected date
+        // Defaults to numberOfDays if date is invalid (Like Feb 31)
+        date.value = currentDate <= numberOfDays? currentDate : numberOfDays;
+    }
+
+    month.addEventListener('change', checkMonth);
 </script>
 
 <script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -59,9 +59,8 @@
         }
 
         .input-group {
-            display: grid;
+            display: inline-grid;
             grid-template-columns: 1fr auto auto auto;
-            width: 50%;
             margin: 32px auto;
         }
 
@@ -343,7 +342,6 @@
         window.dateValue = `${new Date().getFullYear()}-${Number(month.value)}-${Number(date.value)}`;
 
         history.pushState({username}, '', '#' + username);
-        window.day = (new Date(dateValue)).toLocaleString('en-us', {month: 'long', day: 'numeric'});
 
         showLoadingIndicator();
         // get rid of any existing content
@@ -363,7 +361,7 @@
                 }
 
                 if (!hasContent) {
-                    throw `Sorry, we couldn't find any tweets by <b>${window.username}</b> on <b>${window.day}</b>😕`;
+                    throw `Sorry, we couldn't find any tweets by <b>${window.username}</b> on <b>${thisDay.textContent}</b>😕`;
                 }
 
                 injectContentIntoPage(tweetsHtml.join("\n"), true);

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,6 +27,9 @@
             padding: 0;
             box-sizing: border-box;
         }
+
+        ::-webkit-datetime-edit-fields-wrapper { background: transparent; }
+        ::-webkit-inner-spin-button { display: none; }
  
         html{ 
             scroll-behavior: smooth;
@@ -56,25 +59,29 @@
         }
 
         .input-group {
-            display: flex;
+            display: grid;
+            grid-template-columns: 1fr 190px auto;
             width: 50%;
             margin: 32px auto;
         }
 
-        #username-input {
-            flex: 1;
-            height: 3.0rem;
+        .input-group > input {
+            padding: 0.5rem;
             background: none;
-            padding: 0.5rem 0.5rem;
-            font-size: 20px;
             outline: none;
+            border: 2px solid #0d47a1;
+            font-size: 20px;
+            font-family: inherit;
+        }
+
+        #username-input {
+            font-size: 20px;
             /* A Twitter-y colour border: 2px solid #3B94D9; */
             border: 2px solid #0d47a1;
             -webkit-transition: all 0.28s ease;
             transition: all 0.28s ease;
             border-top-left-radius: 10px;
             border-bottom-left-radius: 10px;
-            font-family: inherit;
         }
 
         #submit-button {
@@ -83,11 +90,12 @@
             color: white;
             height: 3.0rem;
             padding: 0.5rem 1rem;
-	    cursor: pointer;
+            cursor: pointer;
             border-top-right-radius: 10px;
             border-bottom-right-radius: 10px;
             border: none;
             font-family: inherit;
+            min-width: 120px;
         }
 
         #loading-indicator {
@@ -159,7 +167,7 @@
             }
 
             .input-group {
-                flex-direction: column;
+                grid-template-columns: 1fr;
                 width: 95%;
             }
 
@@ -171,7 +179,14 @@
 
         @media screen and (min-width: 601px) and (max-width: 800px) {
             .input-group {
-                width: 70%;
+                width: 100%;
+            }
+        }
+
+        @media screen and (min-width: 601px) {
+            #date-input {
+                border-left: none;
+                border-right: none;
             }
         }
     </style>
@@ -185,6 +200,7 @@ See what you've tweeted on this day in the past.
     <div class="input-group">
         <input id="username-input" type="text" name="username" placeholder="Your Twitter username" autocomplete="off"
                required>
+        <input id="date-input" type="date">
         <button id="submit-button" type="submit">Show me</button>
     </div>
     <div id="help-text">
@@ -203,6 +219,13 @@ See what you've tweeted on this day in the past.
 <button onclick="shareToTwitter()" id="shareButton" title="Share on Twitter">
 <img id="shareImage" src="./img/twitter_icon.png"></button>
 <button onclick="backToTop()" id="topBtn" title="Back to top">👆</button>
+
+<script>
+    // Set the default date input value to today
+    var date = document.getElementById('date-input');
+    var today = new Date().toISOString().substr(0, 10);
+    date.value = today;
+</script>
 
 <script>
     var tweetsContainer = document.getElementById('tweets-container');

--- a/docs/index.html
+++ b/docs/index.html
@@ -197,7 +197,7 @@
 
 <body>
 <h2>#TwitterThrowback</h2>
-<span>See what you've tweeted on <span id="this_day"></span> in the past.</span>
+<span>See what you've tweeted on <span id="this_day">this day</span> in the past.</span>
 <form onsubmit="handleFormSubmit(event);">
     <div class="input-group">
         <input id="username-input" type="text" name="username" placeholder="Your Twitter username" autocomplete="off"

--- a/docs/index.html
+++ b/docs/index.html
@@ -198,7 +198,7 @@
 
 <body>
 <h2>#TwitterThrowback</h2>
-See what you've tweeted on this day in the past.
+<span>See what you've tweeted on <span id="this_day"></span> in the past.</span>
 <form onsubmit="handleFormSubmit(event);">
     <div class="input-group">
         <input id="username-input" type="text" name="username" placeholder="Your Twitter username" autocomplete="off"
@@ -241,10 +241,16 @@ See what you've tweeted on this day in the past.
     // Set the default date input value to today
     var month = document.getElementById('month');
     var date = document.getElementById('day');
+    var thisDay = document.getElementById('this_day');
 
     month.value = new Date().getMonth() + 1;
     checkMonth(month.value); // Populate the date options based on the present month
     date.value = new Date().getDate();
+    setThisDayValue();
+
+    function setThisDayValue() {
+        thisDay.textContent = `${month.options[month.selectedIndex].textContent} ${date.value}`;
+    }
 
     function checkMonth() { // Determine the number of days in the selected month
         let selectedMonth = Number(month.value);
@@ -268,9 +274,11 @@ See what you've tweeted on this day in the past.
         // This attempts to set the date value to the previously selected date
         // Defaults to numberOfDays if date is invalid (Like Feb 31)
         date.value = currentDate <= numberOfDays? currentDate : numberOfDays;
+        setThisDayValue();
     }
 
     month.addEventListener('change', checkMonth);
+    day.addEventListener('change', setThisDayValue);
 </script>
 
 <script>
@@ -312,7 +320,7 @@ See what you've tweeted on this day in the past.
     }
 
     function loadThatShit() {
-        loadingIndicator.innerText = `Fetching ${window.username}'s tweets from ${day}...just a sec 🚀`;
+        loadingIndicator.innerText = `Fetching ${window.username}'s tweets from ${thisDay.textContent}...just a sec 🚀`;
         loadingIndicator.style.display = 'block';
         emojiLoad();
     }
@@ -320,7 +328,7 @@ See what you've tweeted on this day in the past.
     function emojiLoad() {
         window.loaderInterval = setInterval(() => {
             let emojis = ['🤔', '📝', '👩‍🏭', '🤗', '🙈', '😸', '🙂', '😅', '💪', '😊'];
-            loadingIndicator.innerText = `Fetching ${window.username}'s tweets from ${day}...just a sec ${emojis[Math.floor(Math.random() * emojis.length)]}`;
+            loadingIndicator.innerText = `Fetching ${window.username}'s tweets from ${thisDay.textContent}...just a sec ${emojis[Math.floor(Math.random() * emojis.length)]}`;
         }, 750);
     }
 </script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -286,14 +286,15 @@ See what you've tweeted on this day in the past.
         event.preventDefault();
         window.username = usernameInput.value;
         window.username = window.username.trim();
+        window.dateValue = date.value || new Date();
 
         history.pushState({username}, '', '#' + username);
-        window.day = (new Date).toLocaleString('en-us', {month: 'long', day: 'numeric'});
+        window.day = (new Date(dateValue)).toLocaleString('en-us', {month: 'long', day: 'numeric'});
 
         showLoadingIndicator();
         // get rid of any existing content
         tweetsContainer.innerHTML = '';
-        getTweetsOnThisDay(username)
+        getTweetsOnThisDay(username, dateValue)
             .then(tweets => {
                 let tweetsHtml = [];
                 let hasContent = false;
@@ -320,11 +321,11 @@ See what you've tweeted on this day in the past.
     /**
      * @param {string} username
      */
-    function getTweetsOnThisDay(username) {
+    function getTweetsOnThisDay(username, date) {
         const today = new Date();
         const utcOffset = today.getTimezoneOffset();
-        const baseApiUrl = `https://europe-west1-tweetedonthisday.cloudfunctions.net/getTweetsOnThisDay?username=${username}&utcOffset=${utcOffset}`;
-        let baseYear = today.getFullYear() - 1;
+        const baseApiUrl = `https://europe-west1-tweetedonthisday.cloudfunctions.net/getTweetsOnThisDay?username=${username}&utcOffset=${utcOffset}&date=${date}`;
+        let baseYear = today.getFullYear();
         let years = [];
         // request in three-year batches to improve speed
         while (baseYear > 2005) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -378,7 +378,7 @@
     function getTweetsOnThisDay(username, day, month) {
         const today = new Date();
         const utcOffset = today.getTimezoneOffset();
-        const baseApiUrl = `https://europe-west1-oldtweetstoday.cloudfunctions.net/getTweetsOnThisDay?username=${username}&utcOffset=${utcOffset}&day=${day}&month=${month}`;
+        const baseApiUrl = `https://europe-west1-tweetedonthisday.cloudfunctions.net/getTweetsOnThisDay?username=${username}&utcOffset=${utcOffset}&day=${day}&month=${month}`;
         let baseYear = today.getFullYear();
         let years = [];
         // request in three-year batches to improve speed

--- a/docs/index.html
+++ b/docs/index.html
@@ -239,9 +239,9 @@
 
 <script>
     // Set the default date input value to today
-    var month = document.getElementById('month');
-    var day = document.getElementById('day');
-    var thisDay = document.getElementById('this_day');
+    window.month = document.getElementById('month');
+    window.day = document.getElementById('day');
+    window.thisDay = document.getElementById('this_day');
 
     month.value = new Date().getMonth() + 1;
     checkMonth(month.value); // Populate the date options based on the present month

--- a/docs/index.html
+++ b/docs/index.html
@@ -60,12 +60,12 @@
 
         .input-group {
             display: grid;
-            grid-template-columns: 1fr 190px auto;
+            grid-template-columns: 1fr auto auto auto;
             width: 50%;
             margin: 32px auto;
         }
 
-        .input-group > input {
+        select, input {
             padding: 0.5rem;
             background: none;
             outline: none;
@@ -184,8 +184,11 @@
         }
 
         @media screen and (min-width: 601px) {
-            #date-input {
+            select[name="month"] {
                 border-left: none;
+                border-right: none;
+            }
+            select[name="day"] {
                 border-right: none;
             }
         }
@@ -200,7 +203,53 @@ See what you've tweeted on this day in the past.
     <div class="input-group">
         <input id="username-input" type="text" name="username" placeholder="Your Twitter username" autocomplete="off"
                required>
-        <input id="date-input" type="date">
+        <select name="month" id="month">
+            <option value="1">January</option>
+            <option value="2">February</option>
+            <option value="3">March</option>
+            <option value="4">April</option>
+            <option value="5">May</option>
+            <option value="6">June</option>
+            <option value="7">July</option>
+            <option value="8">August</option>
+            <option value="9">September</option>
+            <option value="10">October</option>
+            <option value="11">November</option>
+            <option value="12">December</option>
+        </select>
+        <select name="day" id="day">
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>
+            <option value="6">6</option>
+            <option value="7">7</option>
+            <option value="8">8</option>
+            <option value="9">9</option>
+            <option value="10">10</option>
+            <option value="11">11</option>
+            <option value="12">12</option>
+            <option value="13">13</option>
+            <option value="14">14</option>
+            <option value="15">15</option>
+            <option value="16">16</option>
+            <option value="17">17</option>
+            <option value="18">18</option>
+            <option value="19">19</option>
+            <option value="20">20</option>
+            <option value="21">21</option>
+            <option value="22">22</option>
+            <option value="23">23</option>
+            <option value="24">24</option>
+            <option value="25">25</option>
+            <option value="26">26</option>
+            <option value="27">27</option>
+            <option value="28">28</option>
+            <option value="29">29</option>
+            <option value="30">30</option>
+            <option value="31">31</option>
+        </select>
         <button id="submit-button" type="submit">Show me</button>
     </div>
     <div id="help-text">

--- a/docs/index.html
+++ b/docs/index.html
@@ -272,9 +272,9 @@ See what you've tweeted on this day in the past.
 <script>
     // Set the default date input value to today
     var month = document.getElementById('month');
-    var day = document.getElementById('day');
+    var date = document.getElementById('day');
     month.value = new Date().getMonth() + 1;
-    day.value = new Date().getDate();
+    date.value = new Date().getDate();
 </script>
 
 <script>
@@ -336,7 +336,7 @@ See what you've tweeted on this day in the past.
         event.preventDefault();
         window.username = usernameInput.value;
         window.username = window.username.trim();
-        window.dateValue = date.value || new Date();
+        window.dateValue = `${new Date().getFullYear()}-${Number(month.value)}-${Number(date.value)}`;
 
         history.pushState({username}, '', '#' + username);
         window.day = (new Date(dateValue)).toLocaleString('en-us', {month: 'long', day: 'numeric'});

--- a/docs/index.html
+++ b/docs/index.html
@@ -239,21 +239,21 @@
 <script>
     // Set the default date input value to today
     var month = document.getElementById('month');
-    var date = document.getElementById('day');
+    var day = document.getElementById('day');
     var thisDay = document.getElementById('this_day');
 
     month.value = new Date().getMonth() + 1;
     checkMonth(month.value); // Populate the date options based on the present month
-    date.value = new Date().getDate();
+    day.value = new Date().getDate();
     setThisDayValue();
 
     function setThisDayValue() {
-        thisDay.textContent = `${month.options[month.selectedIndex].textContent} ${date.value}`;
+        thisDay.textContent = `${month.options[month.selectedIndex].textContent} ${day.value}`;
     }
 
     function checkMonth() { // Determine the number of days in the selected month
         let selectedMonth = Number(month.value);
-        let selectedDate = date.value;
+        let selectedDate = day.value;
         if ([1,3,5,7,8,10,12].includes(selectedMonth)) {
             populateDays(31, selectedDate);
         } else if ([4,6,9,11].includes(selectedMonth)) {
@@ -272,7 +272,7 @@
         }
         // This attempts to set the date value to the previously selected date
         // Defaults to numberOfDays if date is invalid (Like Feb 31)
-        date.value = currentDate <= numberOfDays? currentDate : numberOfDays;
+        day.value = currentDate <= numberOfDays? currentDate : numberOfDays;
         setThisDayValue();
     }
 
@@ -339,14 +339,13 @@
         event.preventDefault();
         window.username = usernameInput.value;
         window.username = window.username.trim();
-        window.dateValue = `${new Date().getFullYear()}-${Number(month.value)}-${Number(date.value)}`;
 
         history.pushState({username}, '', '#' + username);
 
         showLoadingIndicator();
         // get rid of any existing content
         tweetsContainer.innerHTML = '';
-        getTweetsOnThisDay(username, dateValue)
+        getTweetsOnThisDay(username, day.value, month.value)
             .then(tweets => {
                 let tweetsHtml = [];
                 let hasContent = false;
@@ -373,10 +372,10 @@
     /**
      * @param {string} username
      */
-    function getTweetsOnThisDay(username, date) {
+    function getTweetsOnThisDay(username, day, month) {
         const today = new Date();
         const utcOffset = today.getTimezoneOffset();
-        const baseApiUrl = `https://europe-west1-tweetedonthisday.cloudfunctions.net/getTweetsOnThisDay?username=${username}&utcOffset=${utcOffset}&date=${date}`;
+        const baseApiUrl = `https://europe-west1-oldtweetstoday.cloudfunctions.net/getTweetsOnThisDay?username=${username}&utcOffset=${utcOffset}&day=${day}&month=${month}`;
         let baseYear = today.getFullYear();
         let years = [];
         // request in three-year batches to improve speed


### PR DESCRIPTION
## This PR adds an option to query for a specific date in the serverless function and adds a date parameter to the URL query params on the client

### Why this PR
Several users who have tested this tool (some of them I have spoken to directly) had mostly one complaint, the ability to specify the date they want to review past tweets for. It makes sense to add this as an option for those who need it

## Implementation logic
### API
I set the serverless function to use the URL date query parameter where available and to default to the current date where unavailable.

### UI
The UI now includes a date input that defaults to the current date. This means that a date query parameter is always sent in the request when the user submits the request. The "fetch" request now include the current year for when the user selects a date between January 1 of the current year and the present date

## Screenshots
### Web
![oldtweetstodayweb](https://user-images.githubusercontent.com/11687809/53170418-59613500-35e0-11e9-8a5d-24a3e061d282.PNG)

### Mobile
![oldtweetstodaymobile](https://user-images.githubusercontent.com/11687809/53170419-59613500-35e0-11e9-93bc-40fcb3ec88a2.PNG)

## A little compromise
Even though the "date" input includes a year value, it is not used in the search as the query only needs the day and month part. I used the default "date" input because there is no simple way to show a month and day input without resorting to using a "select" dropdown and a lot of JavaScript