### PR TITLE
Use 'date' query parameter if available, instead of current date

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ function getTweetsOnThisDay(username, { from, until }, today = new Date()) {
 
     // Generate an array of all the years we're looking for tweets in.
     // Twitter was founded in 2006, so we only need to go as far as that.
-    until = until || 2006;
+    from = parseInt(from) || today.getFullYear();
+    until = parseInt(until) || 2006;
     const years = Array.from(
         {length: parseInt(from) + 1 - parseInt(until)},
         (_, i) => from - i
@@ -83,15 +84,18 @@ exports.getTweetsOnThisDay = (req, res) => {
                 username = username.substr(1);
             }
 
-            // Out function runs in UTC time. So if a user in UTC+1 (offset: -60)
+            // First, we need to get our reference date (day, month, and year range to search for)
+            let today = new Date();
+            let from = parseInt(req.query.from) || today.getFullYear();
+            let until = parseInt(req.query.until) || 2006;
+            let day = parseInt(req.query.day) || today.getDate();
+            let month = parseInt(req.query.month) || today.getMonth() + 1;
+            today = new Date(`${from}-${month}-${day}`);
+            
+            // Our function runs in UTC time. So if a user in UTC+1 (offset: -60)
             // uses our app at 00:30 Feb 16, they'll get tweets made on Feb 15.
-            // We need to change our date query to reflect the day wherever they are
-            let offset = req.query.utcOffset;
-            let from = req.query.from || new Date().getFullYear();
-            let until = req.query.until || null;
-            let day = req.query.day || new Date().getDate();
-            let month = req.query.month || new Date().getMonth() + 1;
-            let today = new Date(`${from}-${month}-${day}`);
+            // We need to change our date query to reflect the day wherever they are.
+            let offset = parseInt(req.query.utcOffset);
             if (offset) {
                 today.setTime(today.getTime() + (-1 * offset * 60 * 1000));
             }

--- a/index.js
+++ b/index.js
@@ -87,12 +87,13 @@ exports.getTweetsOnThisDay = (req, res) => {
             // uses our app at 00:30 Feb 16, they'll get tweets made on Feb 15.
             // We need to change our date query to reflect the day wherever they are
             let offset = req.query.utcOffset;
-            let today = new Date();
+            let date = req.query.date || new Date();
+            let today = new Date(date);
             if (offset) {
                 today.setTime(today.getTime() + (-1 * offset * 60 * 1000));
             }
 
-            let from = req.query.from || today.getFullYear();
+            let from = req.query.from || new Date().getFullYear();
             let until = req.query.until || null;
             return getTweetsOnThisDay(username, { from, until }, today)
                 .then(tweets => respond(res, tweets));

--- a/index.js
+++ b/index.js
@@ -87,14 +87,15 @@ exports.getTweetsOnThisDay = (req, res) => {
             // uses our app at 00:30 Feb 16, they'll get tweets made on Feb 15.
             // We need to change our date query to reflect the day wherever they are
             let offset = req.query.utcOffset;
-            let date = req.query.date || new Date();
-            let today = new Date(date);
+            let from = req.query.from || new Date().getFullYear();
+            let until = req.query.until || null;
+            let day = req.query.day || new Date().getDate();
+            let month = req.query.month || new Date().getMonth() + 1;
+            let today = new Date(`${from}-${month}-${day}`);
             if (offset) {
                 today.setTime(today.getTime() + (-1 * offset * 60 * 1000));
             }
 
-            let from = req.query.from || new Date().getFullYear();
-            let until = req.query.until || null;
             return getTweetsOnThisDay(username, { from, until }, today)
                 .then(tweets => respond(res, tweets));
         default:


### PR DESCRIPTION
## This PR sets the serverless function to use the URL date query parameter where available and to default to the current date where unavailable.

### How to test
Include a date query parameter like below and it will return tweets from that particular day from previous years, up to 2016

`https://europe-west1-oldtweetstoday.cloudfunctions.net/getTweetsOnThisDay?username=oghie_js&from=2019&until=2016&date=2019-1-15`