### PR TITLE
Fix hovering on links pushing nearby text around

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -47,6 +47,7 @@
 
         a {
             text-decoration: none;
+            padding: 4px;
         }
 
         a:hover {


### PR DESCRIPTION
This PR fixes the distortion of text nearby links when the link is in a hover state.
I wouldn't call it a major change so I didn't make a gif, if a gif is necessary though, please indicate. 
So I could get a gif maker and make one with the changes.